### PR TITLE
Mtnhi fix bug

### DIFF
--- a/student_management_fe/Resources/Content.Designer.cs
+++ b/student_management_fe/Resources/Content.Designer.cs
@@ -421,6 +421,24 @@ namespace student_management_fe.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to check student enrollment information for the course!.
+        /// </summary>
+        public static string check_course_has_students_request_failed {
+            get {
+                return ResourceManager.GetString("check_course_has_students_request_failed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to read the response from the server!.
+        /// </summary>
+        public static string check_course_has_students_response_parse_failed {
+            get {
+                return ResourceManager.GetString("check_course_has_students_response_parse_failed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Actions.
         /// </summary>
         public static string column_actions_header {

--- a/student_management_fe/Resources/Content.resx
+++ b/student_management_fe/Resources/Content.resx
@@ -1182,4 +1182,10 @@
   <data name="warning_old_score_will_be_deleted_if_course_repeated" xml:space="preserve">
     <value>Warning: if the student has already taken this course, the previous score will be deleted!</value>
   </data>
+  <data name="check_course_has_students_response_parse_failed" xml:space="preserve">
+    <value>Unable to read the response from the server!</value>
+  </data>
+  <data name="check_course_has_students_request_failed" xml:space="preserve">
+    <value>Failed to check student enrollment information for the course!</value>
+  </data>
 </root>

--- a/student_management_fe/Resources/Content.vi-VN.resx
+++ b/student_management_fe/Resources/Content.vi-VN.resx
@@ -1182,4 +1182,10 @@
   <data name="warning_old_score_will_be_deleted_if_course_repeated" xml:space="preserve">
     <value>Chú ý: nếu sinh viên đã học môn này thì điểm cũ sẽ bị xóa!</value>
   </data>
+  <data name="check_course_has_students_response_parse_failed" xml:space="preserve">
+    <value>Không thể đọc thông tin phản hồi từ server!</value>
+  </data>
+  <data name="check_course_has_students_request_failed" xml:space="preserve">
+    <value>Không thể kiểm tra thông tin sinh viên đăng ký khóa học!</value>
+  </data>
 </root>

--- a/student_management_fe/Services/CourseService.cs
+++ b/student_management_fe/Services/CourseService.cs
@@ -129,7 +129,7 @@ public class CourseService
 
         if (!response.IsSuccessStatusCode)
         {
-            throw new Exception("Không thể kiểm tra thông tin sinh viên đăng ký khóa học!");
+            throw new Exception(_localizer["check_course_has_students_request_failed"]);
         }
 
         var content = await response.Content.ReadAsStringAsync();
@@ -143,7 +143,7 @@ public class CourseService
         }
         catch (JsonException)
         {
-            throw new Exception("Không thể đọc thông tin phản hồi từ server!");
+            throw new Exception(_localizer["check_course_has_students_response_parse_failed"]);
         }
     }
 

--- a/student_management_fe/Views/Pages/AcademicManagements/RegistrationManagement.razor.cs
+++ b/student_management_fe/Views/Pages/AcademicManagements/RegistrationManagement.razor.cs
@@ -187,9 +187,6 @@ public partial class RegistrationManagement
                     CourseId = courseClass.Course.Id,
                     Grade = editingStudent.Grade
                 };
-                //await _courseErollmentService.UpdateStudentGrade(updateStudentGradeRequest);
-                //studentsInClass = await _courseClassService.GetStudentsInClass(courseClass);
-                //Snackbar.Add($"Đã cập nhật điểm số của sinh viên có MSSV {editingStudent.Id}", Severity.Success);
 
                 var messgae = await _courseErollmentService.UpdateStudentGrade(updateStudentGradeRequest);
                 studentsInClass = await _courseClassService.GetStudentsInClass(courseClass);

--- a/student_management_fe/Views/Pages/Home.razor
+++ b/student_management_fe/Views/Pages/Home.razor
@@ -81,7 +81,7 @@
             <MudTh Style="text-align: center; width: 16%">@_localizer["home_column_full_name_header"]</MudTh>
             <MudTh Style="text-align: center; width: 8%">@_localizer["home_column_date_of_birth_header"]</MudTh>
             <MudTh Style="text-align: center; width: 8%">@_localizer["home_column_gender_header"]</MudTh>
-            <MudTh Style="text-align: center; width: 17%" >@_localizer["home_column_faculty_header"]</MudTh>
+            <MudTh Style="text-align: center; width: 17%">@_localizer["home_column_faculty_header"]</MudTh>
             <MudTh Style="text-align: center; width: 8%">@_localizer["home_column_intake_year_header"]</MudTh>
             <MudTh Style="text-align: center; width: 10%">@_localizer["home_column_study_program_header"]</MudTh>
             <MudTh Style="text-align: center; width: 11%">@_localizer["home_column_student_status_header"]</MudTh>
@@ -90,7 +90,7 @@
  
 
         <RowTemplate>
-            <MudTd Style="text-align: center" DataLabel="STT">@((students.IndexOf(context) + 1) + (currentPage - 1) * pageSize)</MudTd>
+            <MudTd Style="text-align: center" DataLabel=@_localizer["column_order_header"]>@((students.IndexOf(context) + 1) + (currentPage - 1) * pageSize)</MudTd>
             <MudTd DataLabel=@_localizer["home_column_student_id_header"] Style="text-align: center">@context.Id</MudTd>
             <MudTd DataLabel=@_localizer["home_column_full_name_header"]>@context.FullName</MudTd>
             <MudTd DataLabel=@_localizer["home_column_date_of_birth_header"] Style="text-align: center">@context.DateOfBirth?.ToString("dd/MM/yyyy")</MudTd>

--- a/student_management_fe/Views/Pages/Home.razor.cs
+++ b/student_management_fe/Views/Pages/Home.razor.cs
@@ -204,8 +204,6 @@ public partial class Home
                 Snackbar.Add(ex.Message, Severity.Error);
             }
         }
- 
-        Console.WriteLine($"Dialog closed with result: {result}");
     }
 
     private async Task ExportTranscript(string mssv)

--- a/student_management_fe/Views/Pages/Settings/StudentStatusSetting.razor
+++ b/student_management_fe/Views/Pages/Settings/StudentStatusSetting.razor
@@ -68,7 +68,7 @@
 
             <RowTemplate>
                 <MudTd DataLabel=@_localizer["column_order_header"] Style="text-align: center">@(availableNextStatus.IndexOf(context) + 1)</MudTd>
-			          <MudTd DataLabel=@_localizer["student_status_setting_column_id_header"] Style="text-align: center">@context.Id</MudTd>
+			    <MudTd DataLabel=@_localizer["student_status_setting_column_id_header"] Style="text-align: center">@context.Id</MudTd>
                 <MudTd DataLabel=@_localizer["student_status_setting_column_status_header"] Style="text-align: center">@context.Name</MudTd>
                 <MudTd DataLabel=@_localizer["column_actions_header"] Style="text-align: center">
                     <MudTooltip Text=@_localizer["all_actions_delete_tooltip"] Color="Color.Error" Arrow="true" Placement="Placement.Top">

--- a/student_management_fe/Views/Shared/UploadFile.razor
+++ b/student_management_fe/Views/Shared/UploadFile.razor
@@ -8,8 +8,7 @@
 <MudStack Style="width: 100%">
     <MudForm Model="@_model"
     @bind-IsValid="_isValid"
-    @bind-IsTouched="_isTouched"
-    Validation="@_validationRules.ValidateValue">
+    @bind-IsTouched="_isTouched">
         <MudItem xs="12">
             <MudFileUpload T="IBrowserFile"
             @ref="@_fileUpload"
@@ -68,11 +67,6 @@
     }
     [Inject] private IStringLocalizer<Content> _localizer { get; set; }
     private Model _model = new();
-    private ModelFluentValidator _validationRules;
-    protected override void OnInitialized()
-    {
-        _validationRules = new ModelFluentValidator(AllowedExtensions);
-    }
 
     private MudFileUpload<IBrowserFile>? _fileUpload;
     private bool _isValid;
@@ -99,7 +93,7 @@
         if (!AllowedExtensions.Contains(Path.GetExtension(_model.File.Name).ToLower()))
         {
             var message = _localizer["upload_file_form_format_warning"];
-            Snackbar.Add($"{message}: {string.Join(", ", AllowedExtensions)}.", MudBlazor.Severity.Warning);
+            Snackbar.Add($"{message}: {string.Join(", ", AllowedExtensions)} !", MudBlazor.Severity.Warning);
             return;
         }
 
@@ -117,27 +111,4 @@
 
     private Task ClearAsync()
         => _fileUpload?.ClearAsync() ?? Task.CompletedTask;
-
-    public class ModelFluentValidator : AbstractValidator<Model>
-    {
-        private readonly string[] _allowedExtensions;
-
-        public ModelFluentValidator(string[] allowedExtensions)
-        {
-            _allowedExtensions = allowedExtensions;
-            RuleFor(x => x.File)
-                .NotNull()
-                .WithMessage("Phải có một tệp tin.")
-                .Must(file => file.Size <= 5 * 1024 * 1024)
-                .WithMessage("Tệp tin phải nhỏ hơn 5MB.")
-                .Must(file => _allowedExtensions.Contains(Path.GetExtension(file.Name).ToLower()))
-                .WithMessage($"File không hợp lệ");
-        }
-
-        public Func<object, string, Task<IEnumerable<string>>> ValidateValue => async (model, propertyName) =>
-        {
-            var result = await ValidateAsync(ValidationContext<Model>.CreateWithOptions((Model)model, x => x.IncludeProperties(propertyName)));
-            return result.IsValid ? Array.Empty<string>() : result.Errors.Select(e => e.ErrorMessage);
-        };
-    }
 }


### PR DESCRIPTION
This pull request introduces several updates to the student management frontend, focusing on improving localization, refactoring validation logic, and cleaning up unused code. The most significant changes include adding localized error messages, removing a custom validation class for file uploads, and enhancing UI localization.

### Localization Improvements:
* Added new localized error messages for course enrollment checks in `Content.Designer.cs`, `Content.resx`, and `Content.vi-VN.resx` for both English and Vietnamese. These include `check_course_has_students_request_failed` and `check_course_has_students_response_parse_failed`. [[1]](diffhunk://#diff-4cbef0c88290ace90dff001f39570759afbc471ab311d15a8889b9297f46ffaaR423-R440) [[2]](diffhunk://#diff-c381592bc18ba2fecbbcf62630fbc5c963ea2cec12a47c42e1c02cf5d45b61a7R1185-R1190) [[3]](diffhunk://#diff-7fc64b86b478a909ff32127da2e84a2209945b7c523781269eeabad6856ff0beR1185-R1190)
* Updated exception messages in `CheckCourseHasStudents` method to use localized strings instead of hardcoded Vietnamese messages. [[1]](diffhunk://#diff-7650f1398678c647d47ee0e3558bb5b2619f30165d17018b0f8e96f6d7f3b7ddL132-R132) [[2]](diffhunk://#diff-7650f1398678c647d47ee0e3558bb5b2619f30165d17018b0f8e96f6d7f3b7ddL146-R146)
* Enhanced column headers in the `Home.razor` file to use localized strings for better internationalization.

### Validation Refactoring:
* Removed the `ModelFluentValidator` class and its associated logic from `UploadFile.razor`, simplifying the file upload validation process. [[1]](diffhunk://#diff-46e922987c6457eba04920c5f272b30bc28b24e673ed259e0f0e3a601ba22e8fL11-R11) [[2]](diffhunk://#diff-46e922987c6457eba04920c5f272b30bc28b24e673ed259e0f0e3a601ba22e8fL71-L75) [[3]](diffhunk://#diff-46e922987c6457eba04920c5f272b30bc28b24e673ed259e0f0e3a601ba22e8fL120-L142)

### Code Cleanup:
* Removed commented-out and unused code in `RegistrationManagement.razor.cs` and `Home.razor.cs` to improve code readability. [[1]](diffhunk://#diff-9133a889c768f77afc3e9b7d5149a028ad4a7a9cf9a7c67cf96847dff65d386aL190-L192) [[2]](diffhunk://#diff-88885502d3999499847f96f12dcb8d86d1256253b6731f0f961f0b029958a8ecL207-L208)
* Adjusted a warning message in `UploadFile.razor` to include a minor punctuation change for consistency.